### PR TITLE
fix(ratchet): disambiguate identical (file,text) findings by occurrence order (fixes #1)

### DIFF
--- a/quality/bin/check-escapes.py
+++ b/quality/bin/check-escapes.py
@@ -133,7 +133,7 @@ LANGUAGES = {
 }
 
 DEFAULT_SKIP_DIRS = [".git", "node_modules", "vendor", "build", ".build", "dist", "target", "__pycache__",
-                     ".venv", "venv", "DerivedData", "Pods", "coverage", ".next", "out"]
+                     ".venv", "venv", "DerivedData", "Pods", "coverage", ".next", "out", "fixtures"]
 
 
 def language(name):

--- a/quality/bin/ratchet.py
+++ b/quality/bin/ratchet.py
@@ -152,18 +152,33 @@ def compare(finding, entry, metrics):
 
 
 def judge(findings, entries, metrics, stored_provenance=None, current_provenance=None):
-    """Sort `findings` against the baseline `entries` into the five outcomes."""
+    """Sort `findings` against the baseline `entries` into the five outcomes.
+
+    Identical `(file, text)` can repeat within a run — two functions over the
+    line sharing a declaration text. They are told apart by occurrence order:
+    the nth entry with a given `(file, text)` matches the nth such finding.
+    `write()` stores entries in finding order, so the positions line up."""
     verdict = Verdict()
-    by_key = {(e["file"], e["text"]): e for e in entries}
+    by_key = {}
+    counts = {}
+    for e in entries:
+        k = (e["file"], e["text"])
+        occ = counts.get(k, 0)
+        counts[k] = occ + 1
+        by_key[k + (occ,)] = e
     seen = set()
+    counts = {}
     for finding in findings:
-        entry = by_key.get(finding.key)
+        occ = counts.get(finding.key, 0)
+        counts[finding.key] = occ + 1
+        key = finding.key + (occ,)
+        entry = by_key.get(key)
         if entry is None:
             verdict.new.append(finding)
             continue
-        seen.add(finding.key)
+        seen.add(key)
         getattr(verdict, compare(finding, entry, metrics)).append((finding, entry))
-    verdict.stale = [e for e in entries if (e["file"], e["text"]) not in seen]
+    verdict.stale = [e for k, e in by_key.items() if k not in seen]
     verdict.drift = drift_between(stored_provenance, current_provenance)
     return verdict
 

--- a/quality/tests/test-ratchet.py
+++ b/quality/tests/test-ratchet.py
@@ -45,6 +45,31 @@ check("the verdict fails on new or worse", v.failed and v.loose)
 check("a clean verdict neither fails nor is loose",
       not ratchet.judge([findings[4]], [entries[3]], ["cc"]).failed and not ratchet.judge([findings[4]], [entries[3]], ["cc"]).loose)
 
+# Two findings in one file sharing a declaration text — `def check(` twice — are
+# told apart by occurrence order, so an unedited tree stays green (they would
+# otherwise collide on the dict key and compare against each other).
+dup = [F("x.py", 3, "def check():", {"cc": 9}),
+       F("x.py", 30, "def check():", {"cc": 12})]
+dup_entries = [f.entry() for f in dup]
+vA = ratchet.judge(dup, dup_entries, ["cc"])
+check("Regression A: identical same-(file,text) findings all hold, none new/stale",
+      len(vA.held) == 2 and not vA.new and not vA.worsened and not vA.stale, str(vars(vA)))
+
+worse = [F("x.py", 3, "def check():", {"cc": 9}),
+         F("x.py", 30, "def check():", {"cc": 14})]  # second one grew
+vB = ratchet.judge(worse, dup_entries, ["cc"])
+check("Regression B: worsening one of a same-(file,text) pair worsens exactly it, the other holds",
+      [f.line for f, _ in vB.worsened] == [30] and [f.line for f, _ in vB.held] == [3]
+      and not vB.new and not vB.stale, str(vars(vB)))
+
+triple = [F("y.py", 3, "def check():", {"cc": 9}),
+          F("y.py", 20, "def check():", {"cc": 10}),
+          F("y.py", 40, "def check():", {"cc": 11})]
+triple_entries = [f.entry() for f in triple]
+vC = ratchet.judge(triple, triple_entries, ["cc"])
+check("Regression C: a same-(file,text) triple all holds on an identical re-run",
+      len(vC.held) == 3 and not vC.new and not vC.worsened and not vC.stale, str(vars(vC)))
+
 tmp = tempfile.mkdtemp(prefix="ratchet-")
 try:
     legacy = os.path.join(tmp, "legacy.json")


### PR DESCRIPTION
Fixes #1.

## Problem

`ratchet.judge()` keyed both baseline entries and findings on the 2-tuple `(file, text)` in a plain dict. When one file has ≥2 baselined findings sharing an identical declaration line — three `def check(` methods, or a minified JS fixture with many `function() {` — `write()` emits duplicate-keyed entries, the dict silently keeps only the last, and **both** current findings collide against that single survivor. One physical function then gets compared against the other's metrics, producing a phantom "N baselined production function(s) got worse" on a tree with **zero edits** — breaking the "day one is green" guarantee.

Shared machinery, so it hit every `judge()` consumer (complexity, escapes, crap, inventory, sarif, public-api); duplication was immune (single finding).

## Fix

Within a single run, disambiguate identical `(file, text)` by **occurrence order**: the nth entry with a given `(file, text)` matches the nth such finding. `write()` stores entries in finding (source/line) order and `judge()` receives findings in that same order, so positions align.

- Key stays **text-not-line** by design — line-shift tolerance (the documented intent) is preserved.
- **No baseline format change**; existing plain-list baselines read unchanged; `write()` untouched.
- Also adds `"fixtures"` to `check-escapes` `DEFAULT_SKIP_DIRS` (secondary noise reduction; flows into `attach.py`'s generated complexity `exclude` globs). Note the keying fix alone resolves the failures — this is just less baseline clutter.

## Tests

Three regressions added to `quality/tests/test-ratchet.py` — identical `(file,text)` pair holds; worsening exactly one of a pair worsens only it; identical triple holds. All three **fail without the `judge()` fix and pass with it**.

## Verification against a real project

Attached to a ~112k-LOC Python/JS project that failed on day one with 6 phantom "got worse" entries (5 from a minified jQuery fixture with 143 identical `function() {`, 1 from a module with three `def check(` methods). With this fix and the jQuery fixture deliberately **kept in scope**, the complexity gate goes green on day one — confirming the keying change, not the exclude, is the cure.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
