### PR TITLE
Add PHP support to the ast-grep and escapes readers

### DIFF
--- a/quality/bin/check-escapes.py
+++ b/quality/bin/check-escapes.py
@@ -130,6 +130,15 @@ LANGUAGES = {
             "shellcheck disable": r"shellcheck\s+disable",
         },
     },
+    "php": {
+        "suffixes": [".php"],
+        "patterns": {
+            "phpstan-ignore": r"@phpstan-ignore",
+            "psalm-suppress": r"@psalm-suppress",
+            "error suppression": r"(?:^|[\s=(,.])@[a-z_]\w*\(",
+            "skipped test": r"markTest(?:Skipped|Incomplete)\(",
+        },
+    },
 }
 
 DEFAULT_SKIP_DIRS = [".git", "node_modules", "vendor", "build", ".build", "dist", "target", "__pycache__",

--- a/quality/bin/extractors/references.py
+++ b/quality/bin/extractors/references.py
@@ -264,6 +264,8 @@ ASTGREP = {
     "ruby": (("class", "module", "method"), ("constant", "identifier")),
     "csharp": (("class_declaration", "interface_declaration", "struct_declaration", "enum_declaration", "method_declaration"),
                ("identifier",)),
+    "php": (("class_declaration", "interface_declaration", "trait_declaration", "enum_declaration",
+             "function_definition", "method_declaration"), ("name",)),
 }
 
 


### PR DESCRIPTION
Teaches two language readers to see PHP, which enables the complexity, duplication, dead-symbol and escapes gates on PHP code:

- references.py: PHP node kinds for the ast-grep declaration/identifier map (class, interface, trait, enum, function, method; identifier token is "name"). Verified against real PHP. Unlocks dead-symbols, and the duplication and layering checks that share this reader.
- check-escapes.py: a PHP language entry (.php suffix plus phpstan-ignore, psalm-suppress, the @ error-suppression operator, and markTestSkipped). The .php suffix here is also what the duplication gate reads.

## What this changes

## How it was tested

- [ ] `python3 quality/bin/gate.py --strict` is green
- [ ] `bash quality/tests/run.sh` is green
- [ ] The change carries its own test (a new gate, reader, language or fix has a case that fails without it)

## If a baseline or ceiling changed

Say why here. Loosening is a policy decision; tightening needs no justification.
